### PR TITLE
Add line number support

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ output
       , "code"       : "function hello($world)"
       , "type"       : "function"
       , "name"       : "hello()"
+      , "line"       : 12
     }
 ]
 ```

--- a/lib/DoxPHP/Parser/Parser.php
+++ b/lib/DoxPHP/Parser/Parser.php
@@ -207,6 +207,7 @@ class Parser
             $block->code .= $token->value;
             if (!$gotName && in_array($token->name, array("T_NS_SEPARATOR", "T_STRING"))) {
                 $block->name .= $token->value;
+                $block->line = $token->line;
             }
             if (!empty($block->name) && !$gotName && !in_array($token->name, array("T_NS_SEPARATOR", "T_STRING", "T_WHITESPACE"))) {
                 $gotName = true;
@@ -262,6 +263,7 @@ class Parser
             if (!$gotName && "T_STRING" === $token->name) {
                 $gotName = true;
                 $block->name .= $token->value."()";
+                $block->line = $token->line;
             }
 
             $tokens->next();

--- a/lib/DoxPHP/Parser/Tokens.php
+++ b/lib/DoxPHP/Parser/Tokens.php
@@ -17,7 +17,8 @@ class Tokens extends \ArrayIterator
         if (is_array($token)) {
             $tok = array(
                 "name"  => token_name($token[0]),
-                "value" => $token[1]
+                "value" => $token[1],
+                "line"  => $token[2],
             );
         } else {
             $tok = array(


### PR DESCRIPTION
Adds line numbers for class and function/method definitions.

Its assumes PHP > 5.2.2 for the return of the line number from `token_get_all`. I can add a version number check if you want, but I figured simpler was better and it encourages the use of semi-current versions of PHP.
