### PR TITLE
remove last parameter from set_error_handler's callback

### DIFF
--- a/bin/doxphp
+++ b/bin/doxphp
@@ -11,7 +11,7 @@ require_once($lib.'/DoxPHP/Parser/Parser.php');
 require_once($lib.'/DoxPHP/Exception/Exception.php');
 require_once($lib.'/DoxPHP/Exception/OutOfBoundsException.php');
 
-set_error_handler(function($errno, $errstr, $errfile, $errline, array $errcontext) {
+set_error_handler(function($errno, $errstr, $errfile, $errline) {
     new ErrorException($errstr, 0, $errno, $errfile, $errline);
 });
 


### PR DESCRIPTION
It was deprected in PHP 7.2 and removed in PHP 8.0 and it was not even used.

Fixes #15
