### PR TITLE
Remove deplicated dollar sign in attribute names

### DIFF
--- a/bin/doxphp2sphinx
+++ b/bin/doxphp2sphinx
@@ -38,7 +38,7 @@ foreach ($blocks as $block) {
     }
 
     if ("variable" === $block->type) {
-        $out .= ".. php:attr:: ".$block->name."\n\n";
+        $out .= ".. php:attr:: ".substr($block->name, 1)."\n\n";
     } elseif ("constant" === $block->type) {
         $out .= ".. php:const:: ".$block->name."\n\n";
     } else {


### PR DESCRIPTION
sphinxcontrib-phpdomain does not expect the $ sign of an attribute to be there. This resulted in duplicated $ sign in the attribute reference <https://pythonhosted.org/sphinxcontrib-phpdomain/reference.html#role-php:attr>.

#### Before:

![2023-04-04-143550_543x334_scrot](https://user-images.githubusercontent.com/23519418/229793551-b86547d3-b748-4966-a3bf-d2153acfe887.png)

#### After:

![2023-04-04-143814_543x334_scrot](https://user-images.githubusercontent.com/23519418/229794064-4bc6edce-07fc-4e6a-8f34-c0cc496a2ea0.png)
