### PR TITLE
Better support for @return and @throws

### DIFF
--- a/bin/doxphp2sphinx
+++ b/bin/doxphp2sphinx
@@ -70,11 +70,11 @@ foreach ($blocks as $block) {
             $out .= "s";
         }
 
-        if ("param" !== $tag->type) {
+        if ("param" !== $tag->type && "throws" !== $tag->type) {
             $out .= ":";
         }
 
-        if (isset($tag->types)) {
+        if (isset($tag->types) && "return" !== $tag->type) {
             $out .= " ".str_replace("\\", "\\\\", implode("|", $tag->types));
         }
 
@@ -82,7 +82,7 @@ foreach ($blocks as $block) {
             $out .= " $".$tag->name;
         }
 
-        if ("param" === $tag->type) {
+        if ("param" === $tag->type || "throws" === $tag->type) {
             $out .= ":";
         }
 
@@ -92,6 +92,14 @@ foreach ($blocks as $block) {
         }
 
         $out .= "\n";
+
+        // In sphinxcontrib-phpdomain, the return type is not in the "returns"
+        // field but in a separated "rtype" field. So if the "return" tag has
+        // a "types" entry, we need to output this additional field.
+        if ("return" === $tag->type && isset($tag->types)) {
+            $types = str_replace("\\", "\\\\", implode("|", $tag->types));
+            $out .= "$prefix$indent:rtype: $types\n";
+        }
     }
     $out .= "\n";
 }

--- a/lib/DoxPHP/Parser/Parser.php
+++ b/lib/DoxPHP/Parser/Parser.php
@@ -181,6 +181,13 @@ class Parser
                     }
                 }
                 $tag['name'] = implode(' ', $words);
+            } elseif ($tag['type'] == 'throws' || $tag['type'] == 'return') {
+                if ($count > 2) {
+                    $tag['types']       = explode("|", $words[1]);
+                    $tag['description'] = trim(implode(" ", array_slice($words, 2)));
+                } elseif ($count > 1) {
+                    $tag['types']       = explode("|", $words[1]);
+                }
             } elseif ($count > 3) {
                 $tag['types']       = explode("|", $words[1]);
                 $tag['name']        = substr($words[2], 1);


### PR DESCRIPTION
- Correctly parse Type and optional description components. See <https://docs.phpdoc.org/latest/guide/references/phpdoc/tags/throws.html> and <https://docs.phpdoc.org/latest/guide/references/phpdoc/tags/return.html>
- Better rST rendering by outputting throws type and rtype field

### Example

```php
	/**
	 * Parse a readable stream into an indexed :php:class:`SphinxInventory` object.
	 *
	 * @param resource	$stream		The resource to parse, opened in read mode.
	 * @param string	$baseURI	The base string to prepend to an object's location to get its final URI.
	 *
	 * @return SphinxInventory		The inventory parsed from the stream.
	 * @throws UnexpectedValueException	If an unexpected value is encountered while parsing.
	 */
```

#### Before:
![2023-04-04-144333_627x518_scrot](https://user-images.githubusercontent.com/23519418/229795931-2faa2ab3-f195-414b-a31a-ba6122923e06.png)

#### After:
![2023-04-04-144251_627x518_scrot](https://user-images.githubusercontent.com/23519418/229795928-b22231b6-563e-439a-b1b8-84e8aca5730c.png)

#### JSON diff:

```diff
--- before.json	2023-04-04 14:49:01.314363680 +0200
+++ after.json	2023-04-04 14:49:24.822424985 +0200
@@ -47,20 +47,18 @@
       {
         "type": "return",
         "types": [
           "SphinxInventory"
         ],
-        "name": "he",
-        "description": "inventory parsed from the stream."
+        "description": "The inventory parsed from the stream."
       },
       {
         "type": "throws",
         "types": [
           "UnexpectedValueException"
         ],
-        "name": "f",
-        "description": "an unexpected value is encountered while parsing."
+        "description": "If an unexpected value is encountered while parsing."
       }
     ],
     "description": "Parse a readable stream into an indexed :php:class:`SphinxInventory` object.",
     "isPrivate": false,
     "isProtected": false,
```