### PR TITLE
Full function signature in rST (functions & methods)

### DIFF
--- a/bin/doxphp2sphinx
+++ b/bin/doxphp2sphinx
@@ -41,6 +41,9 @@ foreach ($blocks as $block) {
         $out .= ".. php:attr:: ".$block->name."\n\n";
     } elseif ("constant" === $block->type) {
         $out .= ".. php:const:: ".$block->name."\n\n";
+    } elseif ("method" === $block->type || "function" === $block->type) {
+        $sig = str_replace('function ', '', $block->code);
+        $out .= ".. php:".$block->type.":: ".$sig."\n\n";
     } else {
         $out .= ".. php:".$block->type.":: ".$block->name."\n\n";
     }


### PR DESCRIPTION
The only part we need to strip from the signature is the 'function' one, sphinxcontrib-phpdomains handles pretty well the rest of the signature.
This adds a lot more details to the docs, by showing where the parameters are, their default values and the optional return value Type hint.

This also allows to visually differentiate instance methods from class
methods.

### Example

```php
class SphinxInventoryParser {

	/**
	 * Parse a readable stream into an indexed :php:class:`SphinxInventory` object.
	 *
	 * @param resource	$stream		The resource to parse, opened in read mode.
	 * @param string	$baseURI	The base string to prepend to an object's location to get its final URI.
	 *
	 * @return SphinxInventory		The inventory parsed from the stream.
	 * @throws UnexpectedValueException	If an unexpected value is encountered while parsing.
	 */
	public function parse($stream, string $baseURI = ''): SphinxInventory {
```

#### Before:
![2023-04-04-184449_718x515_scrot](https://user-images.githubusercontent.com/23519418/229860604-bda8c620-c67a-41b2-a779-d7782b1c2b1b.png)


#### After:
![2023-04-04-184418_718x515_scrot](https://user-images.githubusercontent.com/23519418/229860628-83e986c8-53fe-45e1-ae2b-fa31c818548e.png)

